### PR TITLE
refactor: improve code readability and NaN handling in signal generation

### DIFF
--- a/src/agents/signal/nodes/signal-formatter.ts
+++ b/src/agents/signal/nodes/signal-formatter.ts
@@ -31,9 +31,9 @@ const signalFormattingSchema = z.object({
  * Configuration for signal direction display
  */
 const SIGNAL_CONFIG = {
-  BUY: { emoji: "🚀", label: "Short-term", timeNote: "1-4h re-check" },
-  SELL: { emoji: "🚨", label: "Mid-term", timeNote: "4-12h re-check" },
-  NEUTRAL: { emoji: "📊", label: "Long-term", timeNote: "12-24h re-check" },
+  BUY: { emoji: "🚀" },
+  SELL: { emoji: "🚨" },
+  NEUTRAL: { emoji: "📊" },
 } as const;
 
 /**

--- a/src/agents/signal/prompts/signal-analysis.ts
+++ b/src/agents/signal/prompts/signal-analysis.ts
@@ -3,8 +3,7 @@ import { PromptTemplate } from "@langchain/core/prompts";
 import { z } from "zod";
 
 /**
- * Signal Analysis Schema
- * Zod schema for validating structured output from LLM
+ * Schema for structured signal analysis output
  */
 export const signalAnalysisSchema = z.object({
   shouldGenerateSignal: z.boolean(),
@@ -20,245 +19,160 @@ export const signalAnalysisSchema = z.object({
 });
 
 /**
- * Structured Output Parser for Signal Analysis
+ * Parser for structured output validation
  */
 export const parser = StructuredOutputParser.fromZodSchema(signalAnalysisSchema);
 
 /**
- * Common template parts used across signal analysis prompts
+ * Standard input variables for signal analysis
  */
-const BASE_TEMPLATE = `You are a professional crypto trading signal analyst who specializes in translating complex technical analysis into beginner-friendly insights. Your task is to analyze technical indicators and determine if a trading signal should be generated, while explaining the market situation in simple terms.`;
+const ANALYSIS_INPUT_VARIABLES = [
+  "tokenSymbol", "tokenAddress", "currentPrice", "timestamp",
+  "rsi", "vwapDeviation", "percentB", "adx", "atrPercent", "obvZScore",
+  "triggeredIndicators", "signalCandidates", "confluenceScore", "riskLevel",
+  "formatInstructions"
+];
 
-const ANALYSIS_GUIDELINES = `
+/**
+ * Main signal analysis prompt for LLM evaluation
+ */
+export const signalAnalysisPrompt = new PromptTemplate({
+  inputVariables: ANALYSIS_INPUT_VARIABLES,
+  template: `You are a professional crypto trading signal analyst specializing in beginner-friendly technical analysis interpretation.
 
 ## Analysis Guidelines
 
 **Signal Generation Criteria:**
-- Multiple market indicators must align (market consensus)
-- Risk-reward ratio must be favorable (potential profit vs potential loss)
-- Market conditions must support the signal direction (overall trend alignment)
-- Confidence level must be above 60% (strong conviction in the analysis)
+- Multiple indicators must align (market consensus)
+- Favorable risk-reward ratio
+- Clear directional bias with 60%+ confidence
 
 **Risk Assessment:**
-- LOW: Single indicator trigger, stable market conditions, clear trend
-- MEDIUM: Multiple indicators aligning, moderate price swings, developing trend changes
-- HIGH: Strong market signals, high price volatility, major trend shifts or breakouts
+- LOW: Single indicator, stable conditions, clear trend
+- MEDIUM: Multiple indicators, moderate volatility, trend changes
+- HIGH: Strong signals, high volatility, major breakouts
 
 **Timeframe Classification:**
-- SHORT: Quick trades (minutes to hours) - for active traders
-- MEDIUM: Swing trades (days to weeks) - for regular monitoring
-- LONG: Position trades (weeks to months) - for patient investors
+- SHORT: Minutes to hours (active trading)
+- MEDIUM: Days to weeks (swing trading)
+- LONG: Weeks to months (position trading)
 
-## Current Market Analysis
+## Market Data
 
-**Token**: {tokenSymbol} ({tokenAddress}) (Display token symbol with $ prefix and uppercase)
-**Current Price**: {currentPrice}
-**Analysis Time**: {timestamp}
+**Token**: {tokenSymbol} ({tokenAddress})
+**Price**: {currentPrice} | **Time**: {timestamp}
 
-**Market Health Indicators**:
-- Market Momentum (RSI): {rsi} (shows if token is overbought/oversold)
-- Price vs Average (VWAP Dev): {vwapDeviation}% (how far price is from normal trading range)
-- Volatility Band Position (%B): {percentB} (position within expected price range)
-- Trend Strength (ADX): {adx} (how strong the current trend is)
-- Price Volatility (ATR%): {atrPercent}% (how much price typically moves)
-- Volume Momentum (OBV): {obvZScore} (buying vs selling pressure)
+**Technical Indicators:**
+- RSI: {rsi} (momentum strength)
+- VWAP Deviation: {vwapDeviation}% (price vs average)
+- Bollinger %B: {percentB} (volatility position)
+- ADX: {adx} (trend strength)
+- ATR: {atrPercent}% (volatility level)
+- OBV Z-Score: {obvZScore} (volume momentum)
 
-**Automated Filter Results**:
-- Triggered Market Signals: {triggeredIndicators}
-- Potential Trade Opportunities: {signalCandidates}
-- Market Agreement Score: {confluenceScore}
-- Initial Risk Assessment: {riskLevel}
+**Filter Results:**
+- Triggered: {triggeredIndicators}
+- Candidates: {signalCandidates}
+- Confluence: {confluenceScore}
+- Risk: {riskLevel}
 
-## Analysis Task
+## Task
 
-Based on this comprehensive market analysis, determine if a trading signal should be generated. Focus on explaining the market situation in terms that a beginner can understand, avoiding technical jargon where possible.
+Analyze the data and determine if a trading signal should be generated. Use beginner-friendly explanations focusing on:
+1. How indicators align for market direction
+2. Current market sentiment and momentum
+3. Risk-reward potential across timeframes
+4. Market volatility impact on safety
 
-Consider:
-1. How multiple indicators align to suggest market direction
-2. What the current price action tells us about market sentiment
-3. Risk-reward potential for different trading timeframes
-4. Market volatility and its impact on trade safety
+{formatInstructions}
 
-{formatInstructions}`;
-
-const FINAL_INSTRUCTION = `
-
-Provide your analysis based on the structured format requirements above, using beginner-friendly language in the reasoning`;
-
-/**
- * Helper function to build signal analysis template
- */
-const buildSignalAnalysisTemplate = (): string => {
-  return BASE_TEMPLATE + ANALYSIS_GUIDELINES + FINAL_INSTRUCTION + ".";
-};
-
-/**
- * Standard input variables for signal analysis prompts
- */
-const SIGNAL_ANALYSIS_INPUT_VARIABLES = [
-  "tokenSymbol",
-  "tokenAddress",
-  "currentPrice",
-  "timestamp",
-  "rsi",
-  "vwapDeviation",
-  "percentB",
-  "adx",
-  "atrPercent",
-  "obvZScore",
-  "triggeredIndicators",
-  "signalCandidates",
-  "confluenceScore",
-  "riskLevel",
-  "formatInstructions",
-];
-
-/**
- * Signal Analysis Prompts
- *
- * Various prompt templates used in the signal generation process
- * - LLM analysis prompt
- * - Evidence evaluation prompt
- * - Signal formatting prompt
- *
- * Note: Token symbols should always be displayed with $ prefix and in uppercase (e.g., $BTC, $ETH)
- */
-
-/**
- * LLM Signal Analysis Prompt
- * Composite analysis of technical indicators for signal generation (with beginner-friendly interpretation)
- */
-export const signalAnalysisPrompt = new PromptTemplate({
-  inputVariables: SIGNAL_ANALYSIS_INPUT_VARIABLES,
-  template: buildSignalAnalysisTemplate(),
+Provide structured analysis with clear, accessible reasoning.`,
 });
 
 /**
- * Evidence Evaluation Prompt
- * Evaluation of external data sources to improve signal reliability
+ * Evidence evaluation prompt for external data validation
  */
 export const evidenceEvaluationPrompt = new PromptTemplate({
   inputVariables: ["tokenSymbol", "signalType", "direction", "technicalReasoning", "externalSources"],
-  template: `You are a crypto market research analyst evaluating external evidence to support or contradict technical trading signals.
+  template: `You are evaluating external evidence to support or contradict technical trading signals.
 
-## Evaluation Task
-
-**Technical Signal Context:**
-- Token: {tokenSymbol} (Display with $ prefix and uppercase)
-- Signal Type: {signalType}
+**Signal Context:**
+- Token: {tokenSymbol}
+- Type: {signalType}
 - Direction: {direction}
-- Technical Reasoning: {technicalReasoning}
+- Technical Basis: {technicalReasoning}
 
-**External Data Sources:**
+**External Sources:**
 {externalSources}
 
-## Evaluation Criteria
-
-**Source Reliability:**
-- Official announcements: High weight
-- Verified news outlets: Medium-high weight
-- Social media sentiment: Medium weight
-- Unverified sources: Low weight
-
-**Relevance Assessment:**
-- Direct impact on token fundamentals
+**Evaluation Criteria:**
+- Source reliability (official > verified > social > unverified)
 - Market timing alignment
-- Causal relationship strength
-- Historical precedent
+- Historical precedent strength
+- Direct fundamental impact
 
-**Confidence Scoring:**
+**Confidence Scale:**
 - 0.9-1.0: Strong supporting evidence
-- 0.7-0.8: Moderate supporting evidence
-- 0.5-0.6: Neutral/mixed evidence
-- 0.3-0.4: Contradictory evidence
-- 0.0-0.2: Strong contradictory evidence
+- 0.7-0.8: Moderate support
+- 0.5-0.6: Neutral/mixed
+- 0.3-0.4: Contradictory
+- 0.0-0.2: Strong contradiction
 
-Analyze the external evidence and provide:
-- relevantSources: array of most relevant data points
-- overallConfidence: number (0-1)
-- primaryCause: string (main driving factor if identified)
-- recommendation: INCLUDE or EXCLUDE or UNCERTAIN`,
+Provide: relevantSources, overallConfidence (0-1), primaryCause, recommendation (INCLUDE/EXCLUDE/UNCERTAIN)`,
 });
 
 /**
- * Signal Formatting Prompt
- * Generation of user-friendly signal messages (easy to understand for beginners)
+ * Signal formatting prompt for user-friendly Telegram messages
  */
 export const signalFormattingPrompt = new PromptTemplate({
   inputVariables: [
-    "tokenSymbol",
-    "tokenAddress",
-    "signalType",
-    "direction",
-    "currentPrice",
-    "confidence",
-    "riskLevel",
-    "timeframe",
-    "reasoning",
-    "keyFactors",
-    "marketSentiment",
-    "priceExpectation",
-    "technicalData",
+    "tokenSymbol", "tokenAddress", "signalType", "direction", "currentPrice",
+    "confidence", "riskLevel", "timeframe", "reasoning", "keyFactors",
+    "marketSentiment", "priceExpectation", "technicalData", "language"
   ],
-  template: `You are a crypto trading signal formatter who excels at writing **concise, visually-scannable Telegram messages** that balance "easy actionability" with "intuitive explanation for users who do *not* understand technical analysis (TA)".
+  template: `You are a crypto signal formatter creating concise, scannable Telegram messages for users without technical analysis knowledge.
 
-# Formatting Goals
-1. A reader should instantly know **what action to take** (BUY / SELL / HOLD).
-2. The short explanation must *feel* right even to beginners - use clear analogies instead of TA jargon.
-3. Keep the layout rock-solid in both Telegram Markdown **and** HTML (avoid nested formatting that might break).
+# IMPORTANT
+Write the entire output in **{language}**. Use half-width dashes (-) throughout.
 
-# Input Data Analysis
+# Input Analysis
 **Token**: {tokenSymbol} ({tokenAddress})
-**Signal Type**: {signalType}
-**Direction**: {direction}
-**Current Price**: {currentPrice}
-**Confidence**: {confidence}
-**Risk Level**: {riskLevel}
-**Timeframe**: {timeframe}
+**Signal**: {signalType} | **Direction**: {direction}
+**Price**: {currentPrice} | **Confidence**: {confidence}
+**Risk**: {riskLevel} | **Timeframe**: {timeframe}
 **Reasoning**: {reasoning}
-**Key Factors**: {keyFactors}
-**Market Sentiment**: {marketSentiment}
-**Price Expectation**: {priceExpectation}
-**Technical Data**: {technicalData}
+**Factors**: {keyFactors}
+**Sentiment**: {marketSentiment}
+**Expectation**: {priceExpectation}
+**Technical**: {technicalData}
 
-# Message Format Requirements
-
-Create a message following this improved structure:
-- First line: [ACTION_EMOJI] **[ACTION] $TOKEN_SYMBOL**
-- Second line: 📊 Price: **$PRICE** | 🎯 Confidence: **CONFIDENCE%** | ⚠️ Risk: **RISK_LEVEL**
-- Third line: ⏰ Timeframe: **TIMEFRAME_LABEL** (TIMEFRAME_NOTE)
-- Market Snapshot section with 1-2 sentences using analogies
-- Why section with up to 3 technical indicator explanations
-- Suggested Action section with concrete advice
+# Message Structure
+- Line 1: [EMOJI] **[ACTION] $TOKEN**
+- Line 2: 📊 Price: **$PRICE** | 🎯 Confidence: **X%** | ⚠️ Risk: **LEVEL**
+- Line 3: ⏰ Timeframe: **LABEL** (NOTE)
+- Market Snapshot: 1-2 sentences with analogies
+- Why: Up to 3 technical explanations
+- Suggested Action: Concrete advice
 - DYOR disclaimer
 
-# Formatting Rules
-- ACTION_EMOJI: BUY → 🚀, SELL → 🚨, NEUTRAL/HOLD → 📊
-- ACTION: Use the direction value (BUY/SELL/HOLD)
-- TOKEN_SYMBOL: Use tokenSymbol with $ prefix, uppercase (e.g., $BONK)
-- PRICE: Format with appropriate decimal places (max 8 digits, prefer 5 for readability)
-- CONFIDENCE: Integer percentage without space (e.g., 70%)
-- RISK_LEVEL: Capitalize first letter of riskLevel (LOW → Low, MEDIUM → Medium, HIGH → High)
-- TIMEFRAME_LABEL: SHORT → Short-term, MEDIUM → Mid-term, LONG → Long-term
-- TIMEFRAME_NOTE:
-  - SHORT → "1-4h re-check"
-  - MEDIUM → "4-12h re-check"
-  - LONG → "12-24h re-check"
+# Format Rules
+**Emojis**: BUY → 🚀, SELL → 🚨, NEUTRAL → 📊
+**Token**: $ prefix, uppercase (e.g., $BONK)
+**Price**: Appropriate decimals (max 8, prefer 5)
+**Confidence**: Integer % without space (70%)
+**Risk**: Title case (Low/Medium/High)
+**Timeframes**:
+- SHORT → Short-term (1-4h re-check)
+- MEDIUM → Mid-term (4-12h re-check)
+- LONG → Long-term (12-24h re-check)
 
-# Output Instructions
-Return **ONLY** a JSON object with these exact fields:
-{{
-  "level": 1 | 2 | 3,
-  "title": "string (action emoji + [ACTION] + token symbol)",
-  "message": "string (complete formatted message)",
-  "priority": "LOW" | "MEDIUM" | "HIGH",
-  "tags": ["array", "of", "strings"]
-}}
+# Output
+Return JSON with: level (1|2|3), title, message, priority (LOW|MEDIUM|HIGH), tags (array)
 
-Level assignment:
+**Level assignment:**
 - 3: HIGH risk OR confidence ≥ 80%
 - 2: MEDIUM risk OR confidence 60-79%
 - 1: Otherwise
 
-Write the complete formatted message based on the provided data.`,
+Write complete formatted message in {language}.`,
 });

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,0 +1,11 @@
+/**
+ * Safely parses numeric values from strings, handling null/undefined/empty values and NaN
+ * @param value - String value to parse (from database or external source)
+ * @returns Parsed number if valid, null if invalid/empty
+ */
+export const safeParseNumber = (value: string | null | undefined): number | null => {
+  if (!value || value.trim() === "") return null;
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};


### PR DESCRIPTION
### Key Improvements

#### 1. NaN Value Handling
- Add `safeParseNumber` utility for robust numeric validation
- Implement `validateTechnicalAnalysis` with minimum 3-indicator requirement
- Eliminate NaN values from technical analysis explanations

#### 2. Code Refactoring
- **Signal Formatter**: Extract TechnicalIndicatorAnalyzer class for better separation of concerns
- **Prompts**: Simplify and standardize prompt templates for better maintainability  
- **Cron**: Centralize technical analysis validation logic
- **Tests**: Update test expectations to match new format

#### 3. Architecture Improvements
- Create configuration objects (SIGNAL_CONFIG, TIMEFRAME_CONFIG) for better maintainability
- Implement single responsibility principle across modules
- Use early return patterns to reduce nesting complexity
- Add comprehensive JSDoc documentation

#### 4. Format Enhancements
- Modern mobile-optimized Telegram message format
- Beginner-friendly technical indicator explanations
- Priority-based indicator selection (top 3 most relevant)
- Half-width punctuation for better compatibility

### Technical Details
- Minimum 3 valid technical indicators required for signal generation
- Robust fallback mechanisms for LLM failures
- Type-safe configuration management
- Improved error handling and logging

This refactor maintains all existing functionality while significantly improving code quality, readability, and reliability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * シグナルメッセージのフォーマットが刷新され、絵文字や太字、マーケットスナップショット、優先度付きインジケーター解説、推奨アクション、DYOR注意書きなどが含まれるようになりました。
  * シグナルの「Why?」セクションで最大3つの主要インジケーター要因を表示。

* **バグ修正**
  * テクニカル指標値の安全なパースとバリデーションにより、不完全なデータによる誤動作を防止。

* **ドキュメント**
  * シグナル分析プロンプトの説明やフォーマット指示がわかりやすく簡潔に改善されました。

* **テスト**
  * 新しいシグナルフォーマットに対応したテストへと更新され、実際の出力内容を検証するようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->